### PR TITLE
Abstract the OpenSSL call into the function decrypt_aes_128_ecb

### DIFF
--- a/lib/matasano.ex
+++ b/lib/matasano.ex
@@ -267,6 +267,20 @@ defmodule Matasano do
   end
 
   @doc """
+  Decrypt the given hexadecimal encoded file at `path` with AES-128 in ECB mode
+  using `key`.
+  """
+  @spec decrypt_aes_128_ecb(Path.t, String.t) :: String.t
+  def decrypt_aes_128_ecb(path, key) do
+    # I'm going to cheat here and shell out to openssl until Erlang OTP 18 is
+    # released, which added code to the crypto module for AES-128 in ECB mode.
+    args = ["aes-128-ecb", "-in", path, "-K", key, "-base64", "-d"]
+    {output, _exit_status} = System.cmd("openssl", args)
+
+    output
+  end
+
+  @doc """
   Returns the first element from `collection` that has a repeated block of the
   given `blocksize`.
 

--- a/test/matasano_test.exs
+++ b/test/matasano_test.exs
@@ -47,16 +47,11 @@ defmodule MatasanoTest do
   end
 
   test "set 1 challenge 7 - aes in ecb mode" do
-    data = Path.join("data", "7.txt")
+    datafile = Path.join("data", "7.txt")
     key = Base.encode16("YELLOW SUBMARINE")
     plaintext = File.read!(Path.join("data", "play-that-funky-music.txt"))
 
-    # I'm going to cheat here and shell out to openssl until Erlang OTP 18 is
-    # released, which added code to the crypto module for AES-128 in ECB mode.
-    args = ["aes-128-ecb", "-in", data, "-K", key, "-base64", "-d"]
-    {output, _exit_status} = System.cmd("openssl", args)
-
-    assert output == plaintext
+    assert Matasano.decrypt_aes_128_ecb(datafile, key) == plaintext
   end
 
   test "set 1 challenge 8 - detect aes in ecb mode" do


### PR DESCRIPTION
This is the first step, as ideally, the function should not expect a path as an argument; it should work on the raw bytes. Initial testing, however, shows that using Matasano.IO.bytes_from_base64/1 and dropping the `-base64` flag from the openssl command does not produce the same results.

This PR is just to test the Travis CI functionality.
